### PR TITLE
Generalize to allow tuple and other iterable input

### DIFF
--- a/easyemail/base.py
+++ b/easyemail/base.py
@@ -226,7 +226,7 @@ class EasyEmail(object):
 
         message['Subject'] = self.subject
         message['From'] = self.sender
-        if isinstance(self.to, list):
+        if hasattr(self.to, '__iter__'):
             message['To'] = ', '.join(self.to)
         else:
             message['To'] = self.to


### PR DESCRIPTION
Hi @niktto, I'm not sure if you're still working on this project but I just wanted to permit recipients to be passed in as a tuple. Thanks! (Checking for `__iter__` returns False for strings and `unicode` objects but true for pretty much anything sane).
